### PR TITLE
ci: add rake task to github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI checks
 
 on: [push, pull_request]
 
-env:
-  ACTIONS_STEP_DEBUG: true
-
 jobs:
   ci-checks:
     runs-on: ubuntu-latest
@@ -20,9 +17,6 @@ jobs:
 
       - name: Run bundle install
         run: bundle config set --local only ci && bundle install
-
-      - name: Debug task
-        run: pwd && bundle info rubocop
 
       - name: Run rake ci
         run: rake ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI checks
 
 on: [push, pull_request]
 
+env:
+  ACTIONS_STEP_DEBUG: true
+
 jobs:
   ci-checks:
     runs-on: ubuntu-latest
@@ -19,7 +22,7 @@ jobs:
         run: bundle config set --local only ci && bundle install
 
       - name: Debug task
-        run: which rubocop && bundle info rubocop
+        run: pwd && bundle info rubocop
 
       - name: Run rake ci
         run: rake ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,8 @@ jobs:
       - name: Run bundle install
         run: bundle config set --local only ci && bundle install
 
+      - name: Debug task
+        run: which rubocop && bundle info rubocop
+
       - name: Run rake ci
         run: rake ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,5 @@ jobs:
       - name: Run bundle install
         run: bundle config set --local only ci && bundle install
 
-      - name: Run Rubocop
-        run: bundle exec rubocop
-
-      - name: Run rspec
-        run: bundle exec rspec
+      - name: Run rake ci
+        run: rake ci

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ Style/StringLiterals:
 
 AllCops:
   NewCops: enable
+  SuggestExtensions: false
   Exclude:
     - 'docs/**/'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,8 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
   Exclude:
-    - 'docs/**/'
+    - docs/**/
+    - vendor/bundle/**/*
 
 Layout/LineLength:
   Max: 100

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development do
 end
 
 group :development, :ci do
+  gem "rake", "~> 13.0"
   gem "rspec", "~> 3.12", require: false
   gem "rubocop", "~> 1.51", require: false
   gem "rubocop-performance", "~> 1.18"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
       ast (~> 2.4.1)
     racc (1.6.2)
     rainbow (3.1.1)
+    rake (13.0.6)
     rbs (2.8.4)
     regexp_parser (2.8.0)
     reverse_markdown (2.1.1)
@@ -93,6 +94,7 @@ PLATFORMS
 
 DEPENDENCIES
   overcommit (~> 0.60.0)
+  rake (~> 13.0)
   rspec (~> 3.12)
   rubocop (~> 1.51)
   rubocop-performance (~> 1.18)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+task default: :ci
+
+task ci: %i[lint specs]
+
+task :lint do
+  sh "rubocop"
+end
+
+task :specs do
+  sh "rspec"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -5,9 +5,9 @@ task default: :ci
 task ci: %i[lint specs]
 
 task :lint do
-  sh "rubocop"
+  sh "bundle exec rubocop"
 end
 
 task :specs do
-  sh "rspec"
+  sh "bundle exec rspec"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ task default: :ci
 task ci: %i[lint specs]
 
 task :lint do
-  sh "bundle exec rubocop"
+  sh "bundle exec rubocop -d"
 end
 
 task :specs do

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ task default: :ci
 task ci: %i[lint specs]
 
 task :lint do
-  sh "bundle exec rubocop -d"
+  sh "bundle exec rubocop"
 end
 
 task :specs do


### PR DESCRIPTION
Added a rake task, `ci`, to a GitHub Actions workflow that runs:
- `bundle exec rubocop`
- `bundle exec rspec`

The idea is to have this passed before accepting any PR.
Closes #4 